### PR TITLE
Simplify form

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,35 @@
 Developed by Hudson Molonglo in collaboration with GAIA Resources and Recordkeeping Innovation
 as part of the Queensland State Archives Digital Archiving Program.
 
-## Dependancies
+## Hiding fields
+
+To hide fields using the  `assets/config/hidden_fields.json` config, add a new entry for the controller type (eg. `agents`), then using the id of the `<section>` element, add a new property (eg. `agent_corporate_entity_names`) with `show` and `defaultValues` arrays.
+Entries in the `show` array are the segments of the id that are generated using its data-attributes. An empty array here indicates that all values should be hidden, as will the section header and if applicable, the menu sidebar link.
+`defaultValues` entries are objects with a path array, and a value.
+It should look something like this: 
+```json
+{
+  "agents": {
+    "agent_corporate_entity_names": {
+      "show": [
+        ["agent_names_", "_authority_id_"],
+        ["agent_names_", "_source_"],
+        ["agent_names_", "_rules_"]
+      ],
+      "defaultValues": [
+        { "path": ["agent_names_", "_source_"], "value": "local" }
+      ]
+    }
+  }
+}
+```
+Once an entry is added, that section's fields will be hidden unless they have been added to `show` array.
+For hiding fields in sub-sections, an entry will need to be added for both the `<section>` id and the field in the parent `<section>`.
+
+The `defaultValues` property allows fields have have mandatory values added to them when hidden.
+
+
+## Dependencies
 
 ### External IDs
 

--- a/backend/model/agent_corporate_entity.rb
+++ b/backend/model/agent_corporate_entity.rb
@@ -1,1 +1,2 @@
 AgentCorporateEntity.include(ExternalIDs)
+AgentCorporateEntity.include(AgentManager::Mixin)

--- a/frontend/assets/config/hidden_fields.json
+++ b/frontend/assets/config/hidden_fields.json
@@ -1,0 +1,14 @@
+{
+  "agents": {
+    "agent_corporate_entity_names": {
+      "show": [
+        ["agent_names_", "_primary_name_"],
+        ["agent_names_", "_subordinate_name_1_"],
+        ["agent_names_", "_subordinate_name_2_"]
+      ],
+      "defaultValues": [
+        { "path": ["agent_names_", "_source_"], "value": "local" }
+      ]
+    }
+  }
+}

--- a/frontend/assets/simplify-form.js
+++ b/frontend/assets/simplify-form.js
@@ -1,0 +1,121 @@
+class SimplifyFields {
+    constructor (config, controller) {
+        this.config = config[controller];
+        this.controller = controller;
+        this.simplify();
+        $(document).on("subrecordcreated.aspace", (event, objectName, subform) => {
+            const subsectionId = this.getItemPath(subform[0].parentElement.dataset.idPath, subform[0].dataset.index);
+            // Dirty hack for getting the correct config name.
+            const splitConfigNames = subform[0].parentElement.dataset.idPath.split(/[0-9]+/);
+            const topmostSectionId = subform[0].closest('div.record-pane > fieldset > section').id;
+            const configSection = config[controller][topmostSectionId];
+            if (typeof configSection === 'undefined' || typeof configSection.show === 'undefined') {
+                return;
+            }
+            config[controller][topmostSectionId].show.forEach(showFieldNames => {
+                if (Array.isArray(showFieldNames) &&
+                    showFieldNames.filter(element => splitConfigNames.map(
+                        element => element.replace('${index}_', '')).includes(element))
+                ) {
+                    this.parseSubsectionVisibility(subform[0], config[controller][topmostSectionId], subsectionId);
+                }
+
+            });
+        });
+    }
+
+    simplify () {
+        document.querySelectorAll('div.record-pane fieldset section')
+            .forEach((section) => {
+                const sectionId = section.id;
+                const currentSectionConfig = this.config[sectionId];
+                if (typeof currentSectionConfig === 'undefined') { return; }
+                if (typeof currentSectionConfig.show === 'undefined' || currentSectionConfig.show.length === 0) {
+                    section.classList.add('hide');
+                    // Check by class name, or by href
+                    const sidebarElement = document.querySelector(`[class*='sidebar-entry-${sectionId}'],[href='#${sectionId}']`);
+                    if (!!sidebarElement) {
+                      sidebarElement.classList.add('hide');
+                    }
+                } else {
+                    this.parseSectionVisibility(section, currentSectionConfig);
+                }
+            });
+    }
+
+    parseSectionFields (sectionField, config, configFieldId) {
+        const flatConfig = config.show.map(element => Array.isArray(element) ? element.join('') : element);
+        if (!flatConfig.includes(configFieldId)) {
+            if (sectionField.tagName === 'SECTION') {
+                sectionField.classList.add('hide');
+            } else {
+                // Get the parent div or section to hide
+                sectionField.closest('.form-group,section').classList.add('hide');
+            }
+        }
+
+        // Add default values from config
+        const defaultMatch = config.defaultValues.find(value => value.path.join('') === configFieldId);
+        const defaultValue = !!defaultMatch ? defaultMatch.value : undefined;
+        if (typeof defaultValue !== 'undefined') {
+            switch (sectionField.tagName) {
+                case 'SELECT':
+                    if (!Array.apply(null, sectionField.options).map(option => option.value).includes(defaultValue)) {
+                        throw new Error('Value provided does not match values listed in the target select element');
+                    } else {
+                        sectionField.value = defaultValue;
+                    }
+                    break;
+                case 'INPUT':
+                    if (sectionField.type === 'checkbox' && typeof defaultValue !== 'boolean') {
+                        throw new Error(`Expected checkbox value to be boolean, but found: ${defaultValue}`);
+                    }
+                case 'TEXTAREA':
+                    sectionField.value = defaultValue;
+                    break;
+                default:
+                    throw new Error(`Unexpected field tag: ${sectionField.tagName}`);
+            }
+        }
+    }
+
+    parseSectionVisibility (section, config) {
+        // Check if it's a section or subsection
+        const subsectionList = section.querySelector('ul.subrecord-form-list');
+        if (subsectionList === null) {
+            subsectionList.querySelector('.form-group input,select,textarea')
+                .forEach(listField => this.parseSectionFields(listField, config, listField.id));
+            return;
+        }
+
+        const subsectionListItems = subsectionList.querySelectorAll('li');
+
+        if (typeof subsectionListItems !== 'undefined' && subsectionListItems.length > 0) {
+            subsectionListItems.forEach((subsectionListItem) => {
+                // Get subsection prefix, and ensure it's not a hidden field
+                const subsectionId = this.getItemPath(subsectionList.dataset.idPath, subsectionListItem.dataset.index);
+                this.parseSubsectionVisibility(subsectionListItem, config, subsectionId);
+            });
+        }
+    }
+
+    parseSubsectionVisibility (subsectionListItem, config, subsectionId) {
+       // Look for matching subsection id prefix, and ensure that it is not a hidden field
+       const listFields = subsectionListItem.querySelectorAll("[id^='" + subsectionId + "_']:not([type='hidden'])");
+       listFields.forEach(listField => {
+           // Support subfields
+           // Search for list indicies surrounded by double underscores. This is a workaround for fields that have `_<number>`
+           // in their id
+           const configFieldId = listField.id.split(/__[0-9]__/).join('__');
+           if (listField.tagName === 'SECTION' && config.show.find(value => value.join('') === listField.id.replace(/_[0-9]+_/, ''))) {
+               listField.classList.add('hide');
+           } else {
+               this.parseSectionFields(listField, config, configFieldId);
+           }
+       });
+    }
+
+    getItemPath (idPath, index) {
+        return idPath.replace('${index}', index);
+    }
+}

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -57,11 +57,11 @@ en:
 
   name_corporate_entity:
     primary_name: Primary name
-    primary_name_tooltip: Primary name
+    primary_name_tooltip: The preferred name of the corporate agency.
     subordinate_name_1: Acronym
-    subordinate_name_1_tooltip: Acronym
+    subordinate_name_1_tooltip: The acronym, based on the Primary name field.
     subordinate_name_2: Alternative name
-    subordinate_name_2_tooltip: Alternative name
+    subordinate_name_2_tooltip: An alternative to the name given by Primary name field.
 
   date:
     inferred_date_source: Inferred source

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -55,6 +55,14 @@ en:
     mandates: Mandates
     function: Functions
 
+  name_corporate_entity:
+    primary_name: Primary name
+    primary_name_tooltip: Primary name
+    subordinate_name_1: Acronym
+    subordinate_name_1_tooltip: Acronym
+    subordinate_name_2: Alternative name
+    subordinate_name_2_tooltip: Alternative name
+
   date:
     inferred_date_source: Inferred source
 

--- a/frontend/views/layout_head.html.erb
+++ b/frontend/views/layout_head.html.erb
@@ -1,14 +1,4 @@
-<!-- Series System plugin javascript -->
-<%= javascript_include_tag "#{AppConfig[:frontend_proxy_prefix]}assets/series-system.js" %>
-
-<% begin %>
-  <% if current_record && RelationshipRules.instance.has_rules_for_jsonmodel_type?(current_record['jsonmodel_type']) %>
-    <!-- Allow series system relationships to be created from required contexts -->
-    <%= javascript_include_tag("series_system_relationships.crud.js") %>
-  <% end %>
-<% rescue %>
-<% end %>
-
+<%= javascript_include_tag "#{AppConfig[:frontend_prefix]}assets/series-system.js" %>
 
 <script type="text/template" id="seriesSystemBrowseActions">
   <li class="divider"></li>
@@ -25,4 +15,11 @@
   <!-- JS for detecting similar agent names  -->
   <link href="<%= "#{AppConfig[:frontend_proxy_prefix]}assets/styles/similar_agencies.css" %>" media="all" rel="stylesheet" type="text/css">
   <%= javascript_include_tag("similar_agencies.js") %>
+  <%= javascript_include_tag "#{AppConfig[:frontend_proxy_prefix]}assets/simplify-form.js" %>
+  <script>
+    $(document).ready(function() {
+        $.getJSON('<%= "#{request.base_url}/assets/config/hidden_fields.json" %>')
+          .then(json => new SimplifyFields(json, '<%= controller_name %>'))
+    });
+  </script>
 <% end %>


### PR DESCRIPTION
@jambun @payten
https://www.pivotaltracker.com/story/show/164320704

Hide fields, sections and side menus, and add default values from config file.
* Currently set up for corporate entities
* The title has been changed to show only the `primary_name` field.
* Field names have been overriden for `agent_names` subsection